### PR TITLE
Add `file_id` column to the `documents` table instead of having it in jsonb metadata

### DIFF
--- a/apps/web/src/types/supabase.ts
+++ b/apps/web/src/types/supabase.ts
@@ -89,6 +89,7 @@ export type Database = {
           created_at: string
           deleted_at: string | null
           embedding: string | null
+          file_id: string | null
           id: number
           metadata: Json | null
         }
@@ -97,6 +98,7 @@ export type Database = {
           created_at?: string
           deleted_at?: string | null
           embedding?: string | null
+          file_id?: string | null
           id?: number
           metadata?: Json | null
         }
@@ -105,6 +107,7 @@ export type Database = {
           created_at?: string
           deleted_at?: string | null
           embedding?: string | null
+          file_id?: string | null
           id?: number
           metadata?: Json | null
         }

--- a/packages/api/src/controllers/overwrite-text.ts
+++ b/packages/api/src/controllers/overwrite-text.ts
@@ -193,10 +193,13 @@ export const overwriteText = async (req: ValidatedRequest, res: Response) => {
 
     // Update the file_id column for the documents we just inserted
     console.log("[OVERWRITE-TEXT] Updating file_id column");
-    await supabase.from("documents")
+    supabase.from("documents")
       .update({ file_id: file_id })
       .eq("metadata->>file_id", file_id)
-      .is("file_id", null);
+      .is("file_id", null)
+      .then(() => {
+        console.log("[OVERWRITE-TEXT] File ID column updated successfully");
+      });
 
     // Update file record
     console.log("[OVERWRITE-TEXT] Updating file record");

--- a/packages/api/src/controllers/overwrite-text.ts
+++ b/packages/api/src/controllers/overwrite-text.ts
@@ -189,6 +189,14 @@ export const overwriteText = async (req: ValidatedRequest, res: Response) => {
       client: supabase,
       tableName: "documents",
     });
+    console.log("[OVERWRITE-TEXT] Documents stored in vector store");
+
+    // Update the file_id column for the documents we just inserted
+    console.log("[OVERWRITE-TEXT] Updating file_id column");
+    await supabase.from("documents")
+      .update({ file_id: file_id })
+      .eq("metadata->>file_id", file_id)
+      .is("file_id", null);
 
     // Update file record
     console.log("[OVERWRITE-TEXT] Updating file record");

--- a/packages/api/src/controllers/resync-file.ts
+++ b/packages/api/src/controllers/resync-file.ts
@@ -255,11 +255,15 @@ export const resyncFile = async (req: ValidatedRequest, res: Response) => {
       console.log("[RESYNC-FILE] Documents stored in vector store");
 
       // Update the file_id column for the documents we just inserted
+      // I don't want to wait for the vector store operation to complete cuz it could take time
       console.log("[RESYNC-FILE] Updating file_id column");
-      await supabase.from("documents")
+      supabase.from("documents")
         .update({ file_id: file_id })
         .eq("metadata->>file_id", file_id)
-        .is("file_id", null);
+        .is("file_id", null)
+        .then(() => {
+          console.log("[RESYNC-FILE] File ID column updated successfully");
+        });
 
       console.log("[RESYNC-FILE] Capturing PostHog event");
       client.capture({

--- a/packages/api/src/controllers/resync-file.ts
+++ b/packages/api/src/controllers/resync-file.ts
@@ -254,6 +254,13 @@ export const resyncFile = async (req: ValidatedRequest, res: Response) => {
       });
       console.log("[RESYNC-FILE] Documents stored in vector store");
 
+      // Update the file_id column for the documents we just inserted
+      console.log("[RESYNC-FILE] Updating file_id column");
+      await supabase.from("documents")
+        .update({ file_id: file_id })
+        .eq("metadata->>file_id", file_id)
+        .is("file_id", null);
+
       console.log("[RESYNC-FILE] Capturing PostHog event");
       client.capture({
         distinctId: apiKeyData.profiles?.email as string,

--- a/packages/api/src/controllers/upload-file.ts
+++ b/packages/api/src/controllers/upload-file.ts
@@ -173,6 +173,13 @@ export const uploadFile = async (req: Request, res: Response) => {
       });
       console.log("[UPLOAD-FILE] Documents stored in vector store");
 
+      // Update the file_id column for the documents we just inserted
+      console.log("[UPLOAD-FILE] Updating file_id column");
+      await supabase.from("documents")
+        .update({ file_id: fileId })
+        .eq("metadata->>file_id", fileId)
+        .is("file_id", null);
+
       console.log("[UPLOAD-FILE] Inserting file record");
       await supabase.from("files").insert({
         file_id: fileId,

--- a/packages/api/src/controllers/upload-file.ts
+++ b/packages/api/src/controllers/upload-file.ts
@@ -175,10 +175,13 @@ export const uploadFile = async (req: Request, res: Response) => {
 
       // Update the file_id column for the documents we just inserted
       console.log("[UPLOAD-FILE] Updating file_id column");
-      await supabase.from("documents")
+      supabase.from("documents")
         .update({ file_id: fileId })
         .eq("metadata->>file_id", fileId)
-        .is("file_id", null);
+        .is("file_id", null)
+        .then(() => {
+          console.log("[UPLOAD-FILE] File ID column updated successfully");
+        });
 
       console.log("[UPLOAD-FILE] Inserting file record");
       await supabase.from("files").insert({

--- a/packages/api/src/controllers/upload-text.ts
+++ b/packages/api/src/controllers/upload-text.ts
@@ -127,10 +127,13 @@ export const uploadText = async (req: Request, res: Response) => {
 
     // Update the file_id column for the documents we just inserted
     console.log("[UPLOAD-TEXT] Updating file_id column");
-    await supabase.from("documents")
+    supabase.from("documents")
       .update({ file_id: fileId })
       .eq("metadata->>file_id", fileId)
-      .is("file_id", null);
+      .is("file_id", null)
+      .then(() => {
+        console.log("[UPLOAD-TEXT] File ID column updated successfully");
+      });
 
     console.log("[UPLOAD-TEXT] Inserting file record");
     await supabase.from("files").insert({

--- a/packages/api/src/controllers/upload-text.ts
+++ b/packages/api/src/controllers/upload-text.ts
@@ -125,6 +125,13 @@ export const uploadText = async (req: Request, res: Response) => {
     });
     console.log("[UPLOAD-TEXT] Documents stored in vector store");
 
+    // Update the file_id column for the documents we just inserted
+    console.log("[UPLOAD-TEXT] Updating file_id column");
+    await supabase.from("documents")
+      .update({ file_id: fileId })
+      .eq("metadata->>file_id", fileId)
+      .is("file_id", null);
+
     console.log("[UPLOAD-TEXT] Inserting file record");
     await supabase.from("files").insert({
       file_id: fileId,

--- a/supabase/functions/_shared/types/supabase.ts
+++ b/supabase/functions/_shared/types/supabase.ts
@@ -89,6 +89,7 @@ export type Database = {
           created_at: string
           deleted_at: string | null
           embedding: string | null
+          file_id: string | null
           id: number
           metadata: Json | null
         }
@@ -97,6 +98,7 @@ export type Database = {
           created_at?: string
           deleted_at?: string | null
           embedding?: string | null
+          file_id?: string | null
           id?: number
           metadata?: Json | null
         }
@@ -105,6 +107,7 @@ export type Database = {
           created_at?: string
           deleted_at?: string | null
           embedding?: string | null
+          file_id?: string | null
           id?: number
           metadata?: Json | null
         }

--- a/supabase/migrations/20250312121051_file_id_column.sql
+++ b/supabase/migrations/20250312121051_file_id_column.sql
@@ -1,0 +1,1 @@
+alter table "public"."documents" add column "file_id" uuid;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced document management by supporting an optional file reference for improved linkage between files and documents.
- **Chores**
	- Updated backend processes and database schema, including additional logging, to ensure consistent file association during document operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Todos

## Before deployment

### Store `file_id` when generating and storing new embeddings
- [x] `/upload_file`
- [x] `/upload_text`
- [x] `/resync_file`
- [x] `/overwrite_text`

## After deployment
### Migrate existing documents to use the `file_id` column
- [ ] execute the SQL below
```sql
UPDATE documents
SET file_id = (metadata->>'file_id')::UUID
WHERE 
  metadata->>'file_id' IS NOT NULL 
  AND (file_id IS NULL OR file_id = '');

-- Verify the migration
SELECT 
  COUNT(*) as total_documents,
  COUNT(file_id) as documents_with_file_id,
  COUNT(*) - COUNT(file_id) as documents_missing_file_id
FROM documents
WHERE deleted_at IS NULL; 
``` 

- [ ] create an index